### PR TITLE
Option.bind and asyncPages

### DIFF
--- a/docs/EarningsClassification.fsx
+++ b/docs/EarningsClassification.fsx
@@ -470,8 +470,7 @@ let tfIdf (docTransformer : DocTransfromer)
             | _ -> None
 
        inverseDocFreq.TryFind termTf.Term
-       |> Option.map computeTfIdf
-       |> Option.flatten
+       |> Option.bind computeTfIdf
             
    doc
    |> tf docTransformer
@@ -595,11 +594,10 @@ let tfIdfNGramsTokenizer (docTransformer: DocTransfromer)
     
     let relevantTerm term = 
         tdIdfofDoc.TryFind term
-        |> Option.map (fun term -> 
+        |> Option.bind (fun term -> 
             match term.Stat with
             | TermFreqInvDocFreq tfIdf when tfIdf > tfIdfThresh -> Some term.Term
             | _ -> None )
-        |> Option.flatten
         
     doc
     |> docTransformer

--- a/docs/EarningsClassification.fsx
+++ b/docs/EarningsClassification.fsx
@@ -46,7 +46,7 @@ open FSharp.Collections.ParallelSeq
 Environment.CurrentDirectory <- __SOURCE_DIRECTORY__
 fsi.AddPrinter<DateTime>(fun dt -> dt.ToString("s"))
 
-#load "TranscriptParsing.fsx"
+//#load "TranscriptParsing.fsx"
 #load "ReturnsAroundEarnings.fsx" 
 
 open TranscriptParsing

--- a/docs/ReturnsAroundEarnings.fsx
+++ b/docs/ReturnsAroundEarnings.fsx
@@ -254,8 +254,8 @@ let threeDayAdjustedReturns (transcript: Transcript): AnnouncementDayReturn opti
     transcript
     |> twoWeekReturnWindow
     |> findRetWindows
-    |> Option.map getAdjustedReturns
-    |> Option.flatten
+    |> Option.bind getAdjustedReturns
+
 
 (**
 #### Compute cumualtive returns

--- a/docs/ReturnsAroundEarnings.fsx
+++ b/docs/ReturnsAroundEarnings.fsx
@@ -37,12 +37,14 @@ For example:
 ## Import packages and load scripts
 *)
 
-#load "TranscriptParsing.fsx"
-#load "Common.fsx"
+//#load "TranscriptParsing.fsx"
+#load "Types.fsx"
+      "Common.fsx"
 
 #r "nuget: Plotly.NET, 2.0.0-preview.6"
 
-open TranscriptParsing
+//open TranscriptParsing
+open Types
 open Common
 
 open System
@@ -55,6 +57,7 @@ fsi.AddPrinter<DateTime>(fun dt -> dt.ToString("s"))
 (**
 ### Reading Transcript data from .json file:
 *)
+
 
 /// JSON data reader
 let readJson (jsonFile: string) =

--- a/docs/TopicModelingDemo.fsx
+++ b/docs/TopicModelingDemo.fsx
@@ -198,8 +198,7 @@ let wordFreqByLabel =
 
 let countWordInGroup word group = 
     wordFreqByLabel.TryFind group
-    |> Option.map (fun wordFreqMap -> wordFreqMap.TryFind word)
-    |> Option.flatten
+    |> Option.bind (fun wordFreqMap -> wordFreqMap.TryFind word)
 
 let screeningScore word =
     match countWordInGroup word Positive, 

--- a/docs/TranscriptParsing.fsx
+++ b/docs/TranscriptParsing.fsx
@@ -236,13 +236,14 @@ teslaDoc
 ## Transcript Record
 
 So far we have worked with individual functions that take in one single argument, an html transcript document. Since they all work with the `TranscriptDocument` type, we can easily combine these functions together to form one single function that returns all the individual bits of data that we want.
+
+We'll use a transcript type from [Types.fsx](Types.html).
 *)
 
-type Transcript = 
-    {Ticker : string
-     Exchange: string
-     Date : DateTime
-     Paragraphs : string []}
+(*** hide ***)
+#load "types.fsx"
+open Types
+
 
 /// Search for ticker, exchange, date and paragraphs
 let parseTrancriptDoc (doc: TranscriptDocument): option<Transcript> =
@@ -346,7 +347,7 @@ let asyncPages (pages: int list) =
     transcripts
 
 
-// let xs = asyncPages [1; 2; 3; 4; 5] |> Async.RunSynchronously
+// let xs = asyncPages [1; 2; 3; 4; 5]
 
 let exampleTranscripts = 
     [200 .. 205]

--- a/docs/Types.fsx
+++ b/docs/Types.fsx
@@ -1,0 +1,6 @@
+
+type Transcript = 
+    {Ticker : string
+     Exchange: string
+     Date : System.DateTime
+     Paragraphs : string []}


### PR DESCRIPTION
- Option.bind is better than Option.map |> Option.flatten it turns out.
- See if you link the new asyncPages function. It gets rid of all the nested Async calls. I think it's easier to reason about. It also makes the throttling easier to control.